### PR TITLE
use relative links to node_modules/

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 
 <head>
   <meta charset="UTF-8" />
-  <script src="/node_modules/browser-cjs/require.js"></script>
+  <script src="node_modules/browser-cjs/require.js"></script>
 
-  <link rel="stylesheet" href="/node_modules/codemirror/lib/codemirror.css">
+  <link rel="stylesheet" href="node_modules/codemirror/lib/codemirror.css">
   <link href="notebook.css" rel="stylesheet" />
 </head>
 


### PR DESCRIPTION
- With a server from this dir, either way works, so why not?  
  Relative might allow serving below domain root.

- With a file:// url, it still won't work but at least prevents error:

      Loading failed for the <script> with source “file:///node_modules/browser-cjs/require.js”.